### PR TITLE
Väčší margin pre ukážky kódu

### DIFF
--- a/app/assets/scss/partials/_prose.scss
+++ b/app/assets/scss/partials/_prose.scss
@@ -57,3 +57,7 @@
     padding-top: govuk-spacing(2);
   }
 }
+
+pre[class*=language-] {
+  margin: 1em 0 !important;
+}


### PR DESCRIPTION
Nadpisy za ukážkou kódu nemajú dosť voľného miesta, keď sa pužívajú takto:

```
<div class="govuk-grid-column-full">
  <pre>...</pre>
 </div>
<div class="govuk-grid-column-two-thirds">
  <h3 class="govuk-heading-m">...</h3>
</div>
```

Toto je shotgun riešenie a posprávnosti by sa tie bloky nemali oddeľovať do samostatných stĺpcov.
