### PR TITLE
Update _in-page-navigation.scss

### DIFF
--- a/src/idsk/components/in-page-navigation/_in-page-navigation.scss
+++ b/src/idsk/components/in-page-navigation/_in-page-navigation.scss
@@ -91,7 +91,7 @@
     .idsk-in-page-navigation--expand {
       .idsk-in-page-navigation__list {
         margin-bottom: 15px;
-        max-height: 350px;
+        max-height: 300px;
         overflow-y: auto;
         padding-top: 15px;
         transition: all 0.2s ease-in;


### PR DESCRIPTION
in-page-navigation changed navigation max-height for mobil/tablet devices

<!--
Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.

During this time, we will not be able to review your pull request. Sorry about that.  

You’re welcome to open it anyway, and we will get back to you as quickly as we can. 

Thank you!
-->
