### PR TITLE
customer-surveys: hiding textarea for second step

### DIFF
--- a/src/idsk/components/customer-surveys/customer-surveys.js
+++ b/src/idsk/components/customer-surveys/customer-surveys.js
@@ -169,6 +169,7 @@ CustomerSurveys.prototype.handleNextButtonClick = function (e) {
         $nextButtonText.innerHTML = 'Ďalej';;
         toggleClass($startIcon[0], 'idsk-customer-surveys__icon--hidden');
         // uncheck all radiobuttons 
+        this.handleRadioButtonPrivateClick.call(this);
         var $radios = $module.querySelectorAll('.govuk-radios__input');
         for (var i = 0; i < $radios.length; i++) {
             $radios[i].checked = false;


### PR DESCRIPTION
<!--
Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.

During this time, we will not be able to review your pull request. Sorry about that.  

You’re welcome to open it anyway, and we will get back to you as quickly as we can. 

Thank you!
-->
