### PR TITLE
fixed multiple cookie banner issue on custom-component sites

### DIFF
--- a/app/views/layouts/component-preview.njk
+++ b/app/views/layouts/component-preview.njk
@@ -4,6 +4,8 @@
  {{ bodyClasses }}
 {% endset %}
 
+{% block cookies %}{% endblock %}
+
 {% block skipLink %}{% endblock %}
 
 {% block header %}{% endblock %}

--- a/app/views/template.njk
+++ b/app/views/template.njk
@@ -40,7 +40,8 @@
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-    {% block bodyStart %}
+    
+    {% block cookies %}
     <!-- COOKIES BANNER -->
       <div class="idsk-cookie-banner " data-nosnippet role="region" aria-label="Cookies na stránke IDSK" hidden="true">
          <!-- COOKIES MESSAGE -->


### PR DESCRIPTION
<!--
Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.

During this time, we will not be able to review your pull request. Sorry about that.  

You’re welcome to open it anyway, and we will get back to you as quickly as we can. 

Thank you!
-->
