### PR TITLE
tabs fix not opening after click on mobile arrow

### DIFF
--- a/src/idsk/components/tabs/tabs.js
+++ b/src/idsk/components/tabs/tabs.js
@@ -155,7 +155,7 @@ Tabs.prototype.unsetAttributes = function ($tab) {
 }
 
 Tabs.prototype.onTabClick = function (e) {
-  if (!(e.target.classList.contains('idsk-tabs__tab') || e.target.classList.contains('idsk-tabs__mobile-tab'))) {
+  if (!(e.target.classList.contains('idsk-tabs__tab') || e.target.classList.contains('idsk-tabs__mobile-tab') || e.target.classList.contains('idsk-tabs__tab-arrow-mobile'))) {
   // Allow events on child DOM elements to bubble up to tab parent
     return false
   }
@@ -163,6 +163,9 @@ Tabs.prototype.onTabClick = function (e) {
   var $newTab = e.target
   var $currentTab = this.getCurrentTab()
 
+  if($newTab.classList.contains('idsk-tabs__tab-arrow-mobile')){
+      $newTab = $newTab.parentElement
+    }
   if ($newTab.nodeName == 'BUTTON'){
     $newTab = this.$tabs[$newTab.getAttribute('item')]
     if($newTab == $currentTab){


### PR DESCRIPTION
<!--
Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.

During this time, we will not be able to review your pull request. Sorry about that.  

You’re welcome to open it anyway, and we will get back to you as quickly as we can. 

Thank you!
-->
