### PR TITLE
Changed input focus in table filter

### DIFF
--- a/src/idsk/components/table-filter/table-filter.scss
+++ b/src/idsk/components/table-filter/table-filter.scss
@@ -12,12 +12,11 @@
     }
 
     .govuk-input:focus, .govuk-select:focus {
-      outline-offset: -3px;
-      box-shadow: inset 0 0 0 3px;
-      @supports (-moz-appearance:none) {
-        outline-offset: -2px;
-        box-shadow: inset 0 .5px 0 3px;
-      }
+      outline: none;
+      border-color: govuk-colour("yellow");
+      border-width: 3px;
+      padding-left: calc(#{govuk-spacing(1)} - 1px);
+      box-shadow: inset 0 0 0 2px black;
     }
 
     .govuk-link {

--- a/src/idsk/components/table-filter/table-filter.scss
+++ b/src/idsk/components/table-filter/table-filter.scss
@@ -13,7 +13,7 @@
 
     .govuk-input:focus, .govuk-select:focus {
       outline: none;
-      border-color: govuk-colour("yellow");
+      border-color: $govuk-focus-colour;
       border-width: $govuk-focus-width;
       padding-left: calc(#{govuk-spacing(1)} - 1px);
       box-shadow: inset 0 0 0 $govuk-border-width-form-element $govuk-input-border-colour;

--- a/src/idsk/components/table-filter/table-filter.scss
+++ b/src/idsk/components/table-filter/table-filter.scss
@@ -16,7 +16,7 @@
       border-color: govuk-colour("yellow");
       border-width: 3px;
       padding-left: calc(#{govuk-spacing(1)} - 1px);
-      box-shadow: inset 0 0 0 2px black;
+      box-shadow: inset 0 0 0 2px $govuk-input-border-colour;
     }
 
     .govuk-link {

--- a/src/idsk/components/table-filter/table-filter.scss
+++ b/src/idsk/components/table-filter/table-filter.scss
@@ -14,9 +14,9 @@
     .govuk-input:focus, .govuk-select:focus {
       outline: none;
       border-color: govuk-colour("yellow");
-      border-width: 3px;
+      border-width: $govuk-focus-width;
       padding-left: calc(#{govuk-spacing(1)} - 1px);
-      box-shadow: inset 0 0 0 2px $govuk-input-border-colour;
+      box-shadow: inset 0 0 0 $govuk-border-width-form-element $govuk-input-border-colour;
     }
 
     .govuk-link {


### PR DESCRIPTION
Outline pri focus stave som musel úplne zrušiť, pretože záporny outline-offest pre vnútorne orámovanie bol vždy rozbitý a nekonzistentný vo firefoxe.