### PR TITLE
id-sk tools imports

### DIFF
--- a/package/idsk/components/accordion/_accordion.scss
+++ b/package/idsk/components/accordion/_accordion.scss
@@ -1,7 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
-
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/accordion") {
 

--- a/package/idsk/components/address/_address.scss
+++ b/package/idsk/components/address/_address.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/address") {
     .idsk-address {

--- a/package/idsk/components/banner/banner.scss
+++ b/package/idsk/components/banner/banner.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/banner") {
     .idsk-banner .app-pane-grey {

--- a/package/idsk/components/button/_button.scss
+++ b/package/idsk/components/button/_button.scss
@@ -2,6 +2,7 @@
 @import "../../overrides/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/button") {
   $idsk-button-colour: govuk-colour("green", $legacy: #00823b); // sass-lint:disable no-color-literals

--- a/package/idsk/components/card/_card.scss
+++ b/package/idsk/components/card/_card.scss
@@ -1,8 +1,8 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
-
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/card") {
   .idsk-card {

--- a/package/idsk/components/character-count/_character-count.scss
+++ b/package/idsk/components/character-count/_character-count.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @import "../../../govuk/components/error-message/error-message";
 @import "../../../govuk/components/hint/hint";

--- a/package/idsk/components/crossroad/_crossroad.scss
+++ b/package/idsk/components/crossroad/_crossroad.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/crossroad") {
   .idsk-crossroad-1 {

--- a/package/idsk/components/customer-surveys-radios/customer-surveys-radios.scss
+++ b/package/idsk/components/customer-surveys-radios/customer-surveys-radios.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/customer-surveys-radios") {
     @include mq($from: desktop) {

--- a/package/idsk/components/customer-surveys-text-area/customer-surveys-text-area.scss
+++ b/package/idsk/components/customer-surveys-text-area/customer-surveys-text-area.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/customer-suerveys-text-area") {
 

--- a/package/idsk/components/customer-surveys/customer-surveys.scss
+++ b/package/idsk/components/customer-surveys/customer-surveys.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/customer-suerveys") {
     .idsk-customer-surveys {

--- a/package/idsk/components/feedback/feedback.scss
+++ b/package/idsk/components/feedback/feedback.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/feedback") {
     #idsk-feedback__content {

--- a/package/idsk/components/footer-extended/footer-extended.scss
+++ b/package/idsk/components/footer-extended/footer-extended.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/footer-extended") {
     $govuk-footer-background: $govuk-canvas-background-colour;

--- a/package/idsk/components/footer/_footer.scss
+++ b/package/idsk/components/footer/_footer.scss
@@ -1,8 +1,8 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
-
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/footer") {
 

--- a/package/idsk/components/header-extended/_header-extended.scss
+++ b/package/idsk/components/header-extended/_header-extended.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "./node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/header-extended") {
   $idsk-header-background: govuk-colour("white") !default;

--- a/package/idsk/components/header-web/_header-web.scss
+++ b/package/idsk/components/header-web/_header-web.scss
@@ -1,5 +1,6 @@
 @import "../../../govuk/base";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/header-web") {
   $idsk-header-background-primary: govuk-colour("white") !default;

--- a/package/idsk/components/header/_header.scss
+++ b/package/idsk/components/header/_header.scss
@@ -1,8 +1,8 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
-
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/header") {
 
@@ -322,7 +322,7 @@
     float: right;
     margin-top: -0.5rem;
   }
-  
+
   .govuk-header__container--full-width {
     .idsk-header__user-icon {
       @include mq ($from: desktop) {
@@ -330,7 +330,7 @@
         margin-right: 0.5rem;
       }
     }
-    
+
     .idsk--header__user-name {
       margin-top: -0.5rem;
     }

--- a/package/idsk/components/in-page-navigation/_in-page-navigation.scss
+++ b/package/idsk/components/in-page-navigation/_in-page-navigation.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/in-page-navigation") {
   .idsk-in-page-navigation {

--- a/package/idsk/components/interactive-map/_interactive-map.scss
+++ b/package/idsk/components/interactive-map/_interactive-map.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/interactive-map") {
     .idsk-interactive-map {

--- a/package/idsk/components/intro-block/intro-block.scss
+++ b/package/idsk/components/intro-block/intro-block.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/intro-block") {
     .idsk-intro-block {

--- a/package/idsk/components/registration-for-event/_registration-for-event.scss
+++ b/package/idsk/components/registration-for-event/_registration-for-event.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/registration-for-event") {
   .idsk-registration-for-event {

--- a/package/idsk/components/related-content/_related-content.scss
+++ b/package/idsk/components/related-content/_related-content.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/related-content") {
   .idsk-related-content {

--- a/package/idsk/components/search-component/search-component.scss
+++ b/package/idsk/components/search-component/search-component.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/search-component") {
   .idsk-search-component {

--- a/package/idsk/components/search-results/search-results.scss
+++ b/package/idsk/components/search-results/search-results.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/search-results") {
   .idsk-search-results {

--- a/package/idsk/components/skip-link/_skip-link.scss
+++ b/package/idsk/components/skip-link/_skip-link.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/skip-link") {
   .idsk-skip-link {

--- a/package/idsk/components/stepper/stepper.scss
+++ b/package/idsk/components/stepper/stepper.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/stepper") {
   $idsk-stepper-link-colour: $govuk-link-colour;

--- a/package/idsk/components/subscription-form/subscription-form.scss
+++ b/package/idsk/components/subscription-form/subscription-form.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/subscription-form") {
   .idsk-subscription-form {

--- a/package/idsk/components/table-filter/table-filter.scss
+++ b/package/idsk/components/table-filter/table-filter.scss
@@ -3,6 +3,7 @@
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
 @import "../../../govuk/objects/grid";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/filter") {
   .idsk-table-filter {

--- a/package/idsk/components/table/_table.scss
+++ b/package/idsk/components/table/_table.scss
@@ -1,5 +1,6 @@
 @import "../../../govuk/base";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/table") {
   .idsk-table {

--- a/package/idsk/components/tabs/_tabs.scss
+++ b/package/idsk/components/tabs/_tabs.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/tabs") {
 

--- a/package/idsk/components/timeline/timeline.scss
+++ b/package/idsk/components/timeline/timeline.scss
@@ -2,6 +2,7 @@
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
 @import "../../../govuk/helpers/typography";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/timeline") {
     .idsk-timeline__content {

--- a/package/idsk/components/warning-text/_warning-text.scss
+++ b/package/idsk/components/warning-text/_warning-text.scss
@@ -1,6 +1,7 @@
 @import "../../../govuk/settings/all";
 @import "../../../govuk/tools/all";
 @import "../../../govuk/helpers/all";
+@import "../../tools/all";
 
 @include govuk-exports("idsk/component/warning-text") {
   .idsk-warning-text {

--- a/package/idsk/overrides/_font-faces.scss
+++ b/package/idsk/overrides/_font-faces.scss
@@ -1,4 +1,4 @@
-@import "../../idsk/tools/font-url";
+@import "../tools/all";
 
 /// Font Face - Source Sans Pro
 ///

--- a/src/idsk/tools/_all.scss
+++ b/src/idsk/tools/_all.scss
@@ -1,1 +1,2 @@
 @import "font-url";
+@import "image-url";


### PR DESCRIPTION
IDSK `tools/_all.scss` sa nikde nevyužíval (čiastočne sa importoval `tools/font-url.scss` v `overrides/_font-faces.scss`). To spôsobilo to že funkcie `idsk-image-url` a `idsk-font-url` neexistovali a robilo to rôzne problémy s cestami k `assets`. 

To, kde importovať `tools/_all.scss` je diskutabilné. Môžeme použiť tento PR na debatu ohľadom tohto problému a tiež kde presne importovať `tools/_all.scss`.