### PR TITLE
ID-48 Serve idsk assets from '/public/assets' as well as '/assets'

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -76,6 +76,7 @@ module.exports = (options) => {
   app.use('/vendor/jquery/', express.static('node_modules/jquery/dist'))
 
   app.use('/assets', express.static(path.join(configPaths.idsk_src, 'assets')))
+  app.use('/public/assets', express.static(path.join(configPaths.idsk_src, 'assets')))
 
   // Turn form POSTs into data that can be used for validation.
   app.use(bodyParser.urlencoded({ extended: true }))


### PR DESCRIPTION
We need to serve idsk assets from '/public/assets' so that the relative path to fonts from the css file work correctly.